### PR TITLE
Rearranging arguments for support of stochastic sampler used in patch based.

### DIFF
--- a/examples/generative/corrdiff/generate.py
+++ b/examples/generative/corrdiff/generate.py
@@ -120,10 +120,16 @@ def main(cfg: DictConfig) -> None:
     # Sampler kwargs
     if sampling_method == "stochastic":
         sampler_kwargs = {
-            "img_shape": img_shape_x,
             "patch_shape": patch_shape_x,
             "overlap_pix": overlap_pix,
             "boundary_pix": boundary_pix,
+            "sigma_min": sigma_min,
+            "sigma_max": sigma_max,
+            "rho": rho,
+            "S_churn": S_churn,
+            "S_min": S_min,
+            "S_max": S_max,
+            "S_noise": S_noise,
         }
     elif sampling_method == "deterministic":
         sampler_kwargs = {
@@ -461,6 +467,7 @@ def generate(
             raise ImportError(
                 "Please get the edm_sampler by running: pip install git+https://github.com/mnabian/edmss.git"
             )
+        sampler_kwargs.update(({"img_shape": img_shape}))
 
     # Instantiate distributed manager.
     dist = DistributedManager()
@@ -535,7 +542,7 @@ def generate(
                     latents,
                     img_lr,
                     class_labels,
-                    randn_like=rnd.randn_like,
+                    randn_like=torch.randn_like,
                     **sampler_kwargs,
                 )
             all_images.append(images)

--- a/modulus/models/diffusion/preconditioning.py
+++ b/modulus/models/diffusion/preconditioning.py
@@ -961,9 +961,9 @@ class EDMPrecondSRV2(_ConditionalPrecond, Module):
     def __init__(
         self,
         img_resolution,
-        img_channels,   # not used see above
         img_in_channels,
         img_out_channels,
+        img_channels=0,   # not used see above
         label_dim=0,
         use_fp16=False,
         sigma_min=0.0,


### PR DESCRIPTION
1. Give `img_channel` a default value for compatibility of ckpts in EDMPrecondSRV2. Since classes are all initialized in kwargs it should be ok.
2. Add `S_churn` and sigma parameters to sampler_kwargs so it is passed from config.
3. Fixed the bug cause artifact by randn_like not random.
4. Rearrange a few arguments used by stochastic sampler.